### PR TITLE
PureScript 0.12 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 sudo: required
-node_js: 6
+node_js: 9
 install:
   - npm install -g bower
   - npm install

--- a/bower.json
+++ b/bower.json
@@ -17,17 +17,17 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-console": "^3.0.0",
-    "purescript-exceptions": "^3.0.0",
-    "purescript-lists": "^4.0.0",
-    "purescript-partial": "^1.2.0",
-    "purescript-profunctor": "^3.0.0",
-    "purescript-strings": "^3.5.0",
-    "purescript-transformers": "^3.0.0",
-    "purescript-unsafe-coerce": "^3.0.0",
-    "purescript-typelevel-prelude": "^2.6.0"
+    "purescript-console": "^4.0.1",
+    "purescript-exceptions": "^4.0.0",
+    "purescript-lists": "^5.0.0",
+    "purescript-partial": "^2.0.0",
+    "purescript-profunctor": "^4.0.0",
+    "purescript-strings": "^4.0.0",
+    "purescript-transformers": "^4.1.0",
+    "purescript-unsafe-coerce": "^4.0.0",
+    "purescript-typelevel-prelude": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-quickcheck": "^4.0.0"
+    "purescript-quickcheck": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^11.0.0",
+    "pulp": "^12.3.0",
     "purescript-psa": "^0.5.0",
-    "purescript": "^0.11.1",
+    "purescript": "^0.12.0",
     "rimraf": "^2.5.4"
   }
 }

--- a/src/Pathy/Gen.purs
+++ b/src/Pathy/Gen.purs
@@ -21,7 +21,7 @@ import Data.Foldable (foldr)
 import Data.List as L
 import Data.NonEmpty ((:|))
 import Data.String.Gen as SG
-import Data.String.NonEmpty (cons)
+import Data.String.NonEmpty.CodeUnits (cons)
 import Pathy (AbsDir, AbsFile, AbsPath, Dir, File, RelDir, RelFile, RelPath, (</>))
 import Pathy as P
 

--- a/src/Pathy/Name.purs
+++ b/src/Pathy/Name.purs
@@ -6,7 +6,7 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (class Newtype)
 import Data.String as S
 import Data.String.NonEmpty (NonEmptyString)
-import Data.String.NonEmpty as NES
+import Data.String.NonEmpty.CodeUnits as NES
 import Data.Symbol (class IsSymbol, SProxy(..))
 import Data.Symbol (reflectSymbol) as Symbol
 import Pathy.Phantom (kind DirOrFile)
@@ -34,7 +34,7 @@ instance showName :: Show (Name a) where
 -- | splitName (Name "foo.baz") == { name: "foo",  extension: Just "baz" }
 -- | ```
 -- | _Note, in real code all strings from this examples would be `NonEmptyString`._
--- | 
+-- |
 -- | Also for any `Name` this property holds:
 -- | ```purescript
 -- | joinName <<< splitName = id
@@ -61,7 +61,7 @@ joinName { name, ext } = Name $ case ext of
   Just ext' -> name <> NES.singleton '.' <> ext'
 
 -- | Retrieves the extension of a name. also see [`splitName`](#v:splitName)
--- | 
+-- |
 -- | ```purescript
 -- | extension (Name ".foo")    == Nothing
 -- | extension (Name "foo.")    == Nothing
@@ -76,7 +76,7 @@ extension = splitName >>> _.ext
 -- | or modified. see [`splitName`](#v:splitName) and [`joinName`](#v:joinName)
 -- | for how a `Name` is split into name and extention part and joined back
 -- | into a `Name`.
--- | 
+-- |
 -- | Also for any `Name` this property holds:
 -- | ```purescript
 -- | alterExtension id = id
@@ -89,7 +89,7 @@ alterExtension
 alterExtension f n =
   let spn = splitName n
   in joinName spn{ext = f spn.ext}
-  
+
 -- | A class for creating `Name` values from type-level strings. This allows us
 -- | to guarantee that a name is not empty at compile-time.
 class IsName sym where

--- a/src/Pathy/Parser.purs
+++ b/src/Pathy/Parser.purs
@@ -16,9 +16,11 @@ import Data.Either (Either(..), either)
 import Data.List (List(..), (:))
 import Data.List as L
 import Data.Maybe (Maybe(..))
-import Data.String as S
+import Data.String (split) as S
+import Data.String.CodeUnits (take, takeRight) as S
 import Data.String.NonEmpty (NonEmptyString)
 import Data.String.NonEmpty as NES
+import Data.String.Pattern (Pattern(..)) as S
 import Pathy.Name (Name(..))
 import Pathy.Path (AbsDir, AbsFile, Path, RelDir, RelFile, currentDir, extendPath, parentOf, rootDir)
 import Pathy.Phantom (class IsRelOrAbs, Dir)

--- a/src/Pathy/Phantom.purs
+++ b/src/Pathy/Phantom.purs
@@ -24,8 +24,8 @@ class IsRelOrAbs (a :: RelOrAbs) where
     -> f a b
     -> r
 
-instance relIsRelOrAbs :: IsRelOrAbs Rel where onRelOrAbs f _ = f id
-instance absIsRelOrAbs :: IsRelOrAbs Abs where onRelOrAbs _ f = f id
+instance relIsRelOrAbs :: IsRelOrAbs Rel where onRelOrAbs f _ = f identity
+instance absIsRelOrAbs :: IsRelOrAbs Abs where onRelOrAbs _ f = f identity
 
 -- | Folds over a value that uses `RelOrAbs` to produce a new result.
 foldRelOrAbs
@@ -59,8 +59,8 @@ class IsDirOrFile (b :: DirOrFile) where
     -> f b
     -> r
 
-instance isDirOrFileDir :: IsDirOrFile Dir where onDirOrFile f _ = f id
-instance isDirOrFileFile :: IsDirOrFile File where onDirOrFile _ f = f id
+instance isDirOrFileDir :: IsDirOrFile Dir where onDirOrFile f _ = f identity
+instance isDirOrFileFile :: IsDirOrFile File where onDirOrFile _ f = f identity
 
 -- | Folds over a value that uses `DirOrFile` to produce a new result.
 foldDirOrFile

--- a/src/Pathy/Printer.purs
+++ b/src/Pathy/Printer.purs
@@ -16,16 +16,18 @@ import Prelude
 
 import Data.Foldable (fold)
 import Data.Maybe (Maybe(..), maybe)
-import Data.Monoid (class Monoid)
 import Data.Newtype (class Newtype, un, unwrap)
-import Data.String as Str
+import Data.String (Pattern(..)) as Str
+import Data.String.CodeUnits (singleton) as Str
 import Data.String.NonEmpty (NonEmptyString)
-import Data.String.NonEmpty as NES
+import Data.String.NonEmpty (NonEmptyReplacement(..), replaceAll, toString, unsafeFromString) as NES
+import Data.String.NonEmpty.CodeUnits (cons, singleton) as NES
 import Partial.Unsafe (unsafePartial)
 import Pathy.Name (Name)
 import Pathy.Path (Path, foldPath, (</>))
 import Pathy.Phantom (class IsDirOrFile, class IsRelOrAbs, Dir, Rel, foldDirOrFile, foldRelOrAbs, kind DirOrFile, kind RelOrAbs)
 import Pathy.Sandboxed (SandboxedPath, sandboxRoot, unsandbox)
+import Prim.TypeError (class Warn, Text)
 
 -- | A `Printer` defines options for printing paths.
 -- |
@@ -81,7 +83,7 @@ printPath r sp =
   in
     printPathRep
       r
-      (foldRelOrAbs (root </> _) id p)
+      (foldRelOrAbs (root </> _) identity p)
 
 -- | Prints a `SandboxedPath` into its canonical `String` representation, using
 -- | the specified printer. This will print a relative path if `b ~ Rel`, which
@@ -100,7 +102,7 @@ unsafePrintPath r sp = printPathRep r (unsandbox sp)
 -- | compile time as a reminder!
 debugPrintPath
   :: forall a b
-   . Warn "debugPrintPath usage"
+   . Warn (Text "debugPrintPath usage")
   => IsRelOrAbs a
   => IsDirOrFile b
   => Printer
@@ -155,7 +157,7 @@ instance semigroupEscaper :: Semigroup Escaper where
   append (Escaper e1) (Escaper e2) = Escaper (e1 <<< e2)
 
 instance monoidEscaper :: Monoid Escaper where
-  mempty = Escaper id
+  mempty = Escaper identity
 
 -- | An escaper that replaces all `'/'` characters in a name with `'-'`s.
 slashEscaper :: Escaper

--- a/src/Pathy/Sandboxed.purs
+++ b/src/Pathy/Sandboxed.purs
@@ -29,7 +29,7 @@ sandbox
   => Path Abs Dir
   -> Path a b
   -> Maybe (SandboxedPath a b)
-sandbox root = map (SandboxedPath root) <<< onRelOrAbs (go (root </> _)) (go id)
+sandbox root = map (SandboxedPath root) <<< onRelOrAbs (go (root </> _)) (go identity)
   where
     go :: forall p. (p -> Path Abs b) -> (p -> Path a b) -> p -> Maybe (Path a b)
     go f coe p =


### PR DESCRIPTION
* Updated ```.travis.yml``` to use Node 9 instead of Node 6 to support ```install-purescript-cli``` usage of the object spread operator.
* Updated Bower dependencies
* Updated pulp and purescript NPM dependencies
* Updated imports
* Removal of effect rows
* Use of ```CodeUnits``` for backward compatibility, but I'm sure switching to ```CodePoints``` in the future would be a good idea.