### PR TITLE
Add roles declarations to forbid unsafe coercions

### DIFF
--- a/src/Pathy/Path.purs
+++ b/src/Pathy/Path.purs
@@ -64,6 +64,8 @@ data Path a b
   | ParentOf (Path Rel Dir)
   | In (Path a Dir) (Name b)
 
+type role Path nominal nominal
+
 derive instance eqPath :: Eq (Path a b)
 derive instance ordPath :: Ord (Path a b)
 


### PR DESCRIPTION
I initially planned to keep the roles phantom and replace usages of unsafeCoerce by coerce, but it would be quite unsafe to be able to coerce between constructors.