### PR TITLE
Replace slashes in a name with `$slash` instead of `-`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Changed `slashEscaper`: replace slashes in a name with `$slash` instead of `-` (#48 by @rintcius)
 
 ## [v8.1.0](https://github.com/purescript-contrib/purescript-pathy/releases/tag/v8.1.0) - 2021-05-06
 

--- a/src/Pathy/Printer.purs
+++ b/src/Pathy/Printer.purs
@@ -160,12 +160,12 @@ instance semigroupEscaper :: Semigroup Escaper where
 instance monoidEscaper :: Monoid Escaper where
   mempty = Escaper identity
 
--- | An escaper that replaces all `'/'` characters in a name with `'-'`s.
+-- | An escaper that replaces all `'/'` characters in a name with `$slash`.
 slashEscaper :: Escaper
-slashEscaper = Escaper (NES.replaceAll slash dash)
+slashEscaper = Escaper (NES.replaceAll slash escaped)
   where
     slash = Str.Pattern "/"
-    dash = NES.NonEmptyReplacement (NES.singleton '-')
+    escaped = NES.NonEmptyReplacement $ unsafePartial NES.unsafeFromString "$slash" 
 
 -- | An escaper that replaces names `"."` and `".."` with `"$dot"` and
 -- | `"$dot$dot"`.
@@ -175,8 +175,8 @@ dotEscaper = Escaper \s -> case NES.toString s of
   "." -> unsafePartial NES.unsafeFromString "$dot"
   _ -> s
 
--- | An escaper that removes all slashes, converts ".." into "$dot$dot", and
--- | converts "." into "$dot".
+-- | An escaper that converts slashes into "$slash", ".." into "$dot$dot", and
+-- | "." into "$dot".
 posixEscaper :: Escaper
 posixEscaper = slashEscaper <> dotEscaper
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -194,6 +194,30 @@ main = do
     (printPath posixPrinter $ sandboxAny rootDir)
     """/"""
 
+  test """printPath posixPrinter - escape . - /C/$dot/"""
+    (printPath posixPrinter $ sandboxAny $ rootDir </> dir (Proxy :: Proxy "C") </> dir (Proxy :: Proxy "."))
+    """/C/$dot/"""
+
+  test """printPath posixPrinter - escape .. - /C/$dot$dot/"""
+    (printPath posixPrinter $ sandboxAny $ rootDir </> dir (Proxy :: Proxy "C") </> dir (Proxy :: Proxy ".."))
+    """/C/$dot$dot/"""
+
+  test """printPath posixPrinter - don't escape ... - /C/.../"""
+    (printPath posixPrinter $ sandboxAny $ rootDir </> dir (Proxy :: Proxy "C") </> dir (Proxy :: Proxy "..."))
+    """/C/.../"""
+
+  test """printPath posixPrinter - don't escape foo.bar - /C/foo.bar/"""
+    (printPath posixPrinter $ sandboxAny $ rootDir </> dir (Proxy :: Proxy "C") </> dir (Proxy :: Proxy "foo.bar"))
+    """/C/foo.bar/"""
+
+  test """printPath posixPrinter - escape / - /C/$slash/"""
+    (printPath posixPrinter $ sandboxAny $ rootDir </> dir (Proxy :: Proxy "C") </> dir (Proxy :: Proxy "/"))
+    """/C/$slash/"""
+
+  test """printPath posixPrinter - escape foo/bar - /C/foo$slashbar/"""
+    (printPath posixPrinter $ sandboxAny $ rootDir </> dir (Proxy :: Proxy "C") </> dir (Proxy :: Proxy "foo/bar"))
+    """/C/foo$slashbar/"""
+
   test' "(</>) - ./../foo/"
     (parentOf currentDir </> dirFoo)
     "./../foo/"


### PR DESCRIPTION
**Description of the change**

Previous behaviour cannot unambiguously unescape back to `/`. New behaviour improves this and is now in line with `dotEscaper`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
