### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#49 by @thomashoneyman)
 
 ## [v8.1.0](https://github.com/purescript-contrib/purescript-pathy/releases/tag/v8.1.0) - 2021-05-06
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210722/packages.dhall sha256:1ceb43aa59436bf5601bac45f6f3781c4e1f0e4c2b8458105b018e5ed8c30f8c
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20211109/packages.dhall sha256:e8d8d5b339f6d46d950da90037c6c38e8809f7e34f727373089ab82c080fc709
 
 in  upstream

--- a/src/Pathy/Gen.purs
+++ b/src/Pathy/Gen.purs
@@ -25,45 +25,45 @@ import Data.String.NonEmpty.CodeUnits (cons)
 import Pathy (AbsDir, AbsFile, AbsPath, Dir, File, RelDir, RelFile, RelPath, (</>))
 import Pathy as P
 
-genName ∷ ∀ m a. MonadGen m ⇒ MonadRec m ⇒ m (P.Name a)
+genName :: forall m a. MonadGen m => MonadRec m => m (P.Name a)
 genName = map P.Name $ cons <$> genChar <*> SG.genString genChar
   where
-  genChar = Gen.oneOf $ CG.genDigitChar :| [CG.genAlpha]
+  genChar = Gen.oneOf $ CG.genDigitChar :| [ CG.genAlpha ]
 
-genDirName :: ∀ m. MonadGen m ⇒ MonadRec m ⇒ m (P.Name Dir)
+genDirName :: forall m. MonadGen m => MonadRec m => m (P.Name Dir)
 genDirName = genName
 
-genFileName :: ∀ m. MonadGen m ⇒ MonadRec m ⇒ m (P.Name File)
+genFileName :: forall m. MonadGen m => MonadRec m => m (P.Name File)
 genFileName = genName
 
 genAbsDirPath :: forall m. MonadGen m => MonadRec m => m AbsDir
-genAbsDirPath = Gen.sized \size → do
-  newSize ← Gen.chooseInt 0 size
+genAbsDirPath = Gen.sized \size -> do
+  newSize <- Gen.chooseInt 0 size
   Gen.resize (const newSize) do
-    parts ∷ L.List (P.Name Dir) ← Gen.unfoldable genName
+    parts :: L.List (P.Name Dir) <- Gen.unfoldable genName
     pure $ foldr (flip P.appendPath <<< P.dir') P.rootDir parts
 
 genAbsFilePath :: forall m. MonadGen m => MonadRec m => m AbsFile
 genAbsFilePath = do
-  dir ← genAbsDirPath
-  file ← genName
+  dir <- genAbsDirPath
+  file <- genName
   pure $ dir </> P.file' file
 
 genAbsAnyPath :: forall m. MonadGen m => MonadRec m => m AbsPath
-genAbsAnyPath = Gen.oneOf $ (Left <$> genAbsDirPath) :| [Right <$> genAbsFilePath]
+genAbsAnyPath = Gen.oneOf $ (Left <$> genAbsDirPath) :| [ Right <$> genAbsFilePath ]
 
 genRelDirPath :: forall m. MonadGen m => MonadRec m => m RelDir
-genRelDirPath = Gen.sized \size → do
-  newSize ← Gen.chooseInt 0 size
+genRelDirPath = Gen.sized \size -> do
+  newSize <- Gen.chooseInt 0 size
   Gen.resize (const newSize) do
-    parts ∷ L.List (P.Name Dir) ← Gen.unfoldable genName
+    parts :: L.List (P.Name Dir) <- Gen.unfoldable genName
     pure $ foldr (flip P.appendPath <<< P.dir') P.currentDir parts
 
 genRelFilePath :: forall m. MonadGen m => MonadRec m => m RelFile
 genRelFilePath = do
-  dir ← genRelDirPath
-  file ← genName
+  dir <- genRelDirPath
+  file <- genName
   pure $ dir </> P.file' file
 
 genRelAnyPath :: forall m. MonadGen m => MonadRec m => m RelPath
-genRelAnyPath = Gen.oneOf $ (Left <$> genRelDirPath) :| [Right <$> genRelFilePath]
+genRelAnyPath = Gen.oneOf $ (Left <$> genRelDirPath) :| [ Right <$> genRelFilePath ]

--- a/src/Pathy/Name.purs
+++ b/src/Pathy/Name.purs
@@ -88,11 +88,9 @@ alterExtension
    . (Maybe NonEmptyString -> Maybe NonEmptyString)
   -> Name n
   -> Name n
-alterExtension f n =
-  let
-    spn = splitName n
-  in
-    joinName spn { ext = f spn.ext }
+alterExtension f n = do
+  let spn = splitName n
+  joinName spn { ext = f spn.ext }
 
 -- | A class for creating `Name` values from type-level strings. This allows us
 -- | to guarantee that a name is not empty at compile-time.

--- a/src/Pathy/Name.purs
+++ b/src/Pathy/Name.purs
@@ -89,8 +89,10 @@ alterExtension
   -> Name n
   -> Name n
 alterExtension f n =
-  let spn = splitName n
-  in joinName spn{ext = f spn.ext}
+  let
+    spn = splitName n
+  in
+    joinName spn { ext = f spn.ext }
 
 -- | A class for creating `Name` values from type-level strings. This allows us
 -- | to guarantee that a name is not empty at compile-time.

--- a/src/Pathy/Parser.purs
+++ b/src/Pathy/Parser.purs
@@ -27,13 +27,14 @@ import Pathy.Phantom (class IsRelOrAbs, Dir)
 
 newtype Parser = Parser
   ( forall z
-   . (RelDir -> z)
-  -> (AbsDir -> z)
-  -> (RelFile -> z)
-  -> (AbsFile -> z)
-  -> z
-  -> String
-  -> z)
+     . (RelDir -> z)
+    -> (AbsDir -> z)
+    -> (RelFile -> z)
+    -> (AbsFile -> z)
+    -> z
+    -> String
+    -> z
+  )
 
 -- | A parser for POSIX paths.
 posixParser :: Parser
@@ -75,13 +76,13 @@ buildPath z init k segs =
       | NES.toString name == "." -> k $ Left (go segs')
       | otherwise -> k $ Right (extendPath (go segs') (Name name))
   where
-    go :: List NonEmptyString -> Path a Dir
-    go = case _ of
-      Nil -> init
-      name : segs'
-        | NES.toString name == ".." -> parentOf (go segs')
-        | NES.toString name == "." -> go segs'
-        | otherwise -> extendPath (go segs') (Name name)
+  go :: List NonEmptyString -> Path a Dir
+  go = case _ of
+    Nil -> init
+    name : segs'
+      | NES.toString name == ".." -> parentOf (go segs')
+      | NES.toString name == "." -> go segs'
+      | otherwise -> extendPath (go segs') (Name name)
 
 parsePath
   :: forall z

--- a/src/Pathy/Path.purs
+++ b/src/Pathy/Path.purs
@@ -18,8 +18,10 @@ module Pathy.Path
   , in'
   , parentOf
   , extendPath
-  , appendPath, (</>)
-  , parentAppend, (<..>)
+  , appendPath
+  , (</>)
+  , parentAppend
+  , (<..>)
   , foldPath
   , peel
   , peelFile
@@ -27,7 +29,8 @@ module Pathy.Path
   , fileName
   , rename
   , renameTraverse
-  , setExtension, (<.>)
+  , setExtension
+  , (<.>)
   , relativeTo
   , refine
   ) where
@@ -272,24 +275,26 @@ infixl 6 setExtension as <.>
 relativeTo :: forall b. Path Abs b -> Path Abs Dir -> Path Rel b
 relativeTo p = coeB <<< step Init (coeD p)
   where
-    step :: Path Rel Dir -> Path Abs Dir -> Path Abs Dir -> Path Rel Dir
-    step acc = case _, _ of
-      p', rp' | p' == rp' -> acc
-      Init, In rp' _ -> step (ParentOf acc) Init rp'
-      In p' n, Init -> In (step acc p' Init) n
-      In p' n, rp'
-        | p' == rp' -> In acc n
-        | otherwise -> In (step acc p' rp') n
-      _, _ ->
-        unsafeCrashWith "`ParentOf` in Pathy.relativeTo (this should be impossible)"
-    -- Unfortunately we can't avoid some coercions in this function unless
-    -- we actually write two different verions of `relativeTo` for file/dir
-    -- paths. Since the actual data representation is same either way the
-    -- coercions are safe.
-    coeD :: forall a. Path a b -> Path a Dir
-    coeD = unsafeCoerce
-    coeB :: forall a. Path a Dir -> Path a b
-    coeB = unsafeCoerce
+  step :: Path Rel Dir -> Path Abs Dir -> Path Abs Dir -> Path Rel Dir
+  step acc = case _, _ of
+    p', rp' | p' == rp' -> acc
+    Init, In rp' _ -> step (ParentOf acc) Init rp'
+    In p' n, Init -> In (step acc p' Init) n
+    In p' n, rp'
+      | p' == rp' -> In acc n
+      | otherwise -> In (step acc p' rp') n
+    _, _ ->
+      unsafeCrashWith "`ParentOf` in Pathy.relativeTo (this should be impossible)"
+
+  -- Unfortunately we can't avoid some coercions in this function unless
+  -- we actually write two different verions of `relativeTo` for file/dir
+  -- paths. Since the actual data representation is same either way the
+  -- coercions are safe.
+  coeD :: forall a. Path a b -> Path a Dir
+  coeD = unsafeCoerce
+
+  coeB :: forall a. Path a Dir -> Path a b
+  coeB = unsafeCoerce
 
 -- | Refines path segments but does not change anything else.
 refine
@@ -301,7 +306,7 @@ refine
   -> Path a b
 refine f d = go
   where
-    go :: forall a' b'. IsDirOrFile b' => Path a' b' -> Path a' b'
-    go Init = Init
-    go (ParentOf p) = ParentOf (go p)
-    go (In p n) = In (go p) (onDirOrFile (_ <<< d) (_ <<< f) n)
+  go :: forall a' b'. IsDirOrFile b' => Path a' b' -> Path a' b'
+  go Init = Init
+  go (ParentOf p) = ParentOf (go p)
+  go (In p n) = In (go p) (onDirOrFile (_ <<< d) (_ <<< f) n)

--- a/src/Pathy/Phantom.purs
+++ b/src/Pathy/Phantom.purs
@@ -20,18 +20,21 @@ class IsRelOrAbs :: RelOrAbs -> Constraint
 class IsRelOrAbs a where
   onRelOrAbs
     :: forall (f :: RelOrAbs -> DirOrFile -> Type) b r
-    . ((f Rel b -> f a b) -> f Rel b -> r)
+     . ((f Rel b -> f a b) -> f Rel b -> r)
     -> ((f Abs b -> f a b) -> f Abs b -> r)
     -> f a b
     -> r
 
-instance relIsRelOrAbs :: IsRelOrAbs Rel where onRelOrAbs f _ = f identity
-instance absIsRelOrAbs :: IsRelOrAbs Abs where onRelOrAbs _ f = f identity
+instance relIsRelOrAbs :: IsRelOrAbs Rel where
+  onRelOrAbs f _ = f identity
+
+instance absIsRelOrAbs :: IsRelOrAbs Abs where
+  onRelOrAbs _ f = f identity
 
 -- | Folds over a value that uses `RelOrAbs` to produce a new result.
 foldRelOrAbs
   :: forall f a b r
-  . IsRelOrAbs a
+   . IsRelOrAbs a
   => (f Rel b -> r)
   -> (f Abs b -> r)
   -> f a b
@@ -61,13 +64,16 @@ class IsDirOrFile b where
     -> f b
     -> r
 
-instance isDirOrFileDir :: IsDirOrFile Dir where onDirOrFile f _ = f identity
-instance isDirOrFileFile :: IsDirOrFile File where onDirOrFile _ f = f identity
+instance isDirOrFileDir :: IsDirOrFile Dir where
+  onDirOrFile f _ = f identity
+
+instance isDirOrFileFile :: IsDirOrFile File where
+  onDirOrFile _ f = f identity
 
 -- | Folds over a value that uses `DirOrFile` to produce a new result.
 foldDirOrFile
   :: forall f b r
-  . IsDirOrFile b
+   . IsDirOrFile b
   => (f Dir -> r)
   -> (f File -> r)
   -> f b

--- a/src/Pathy/Sandboxed.purs
+++ b/src/Pathy/Sandboxed.purs
@@ -31,13 +31,13 @@ sandbox
   -> Maybe (SandboxedPath a b)
 sandbox root = map (SandboxedPath root) <<< onRelOrAbs (go (root </> _)) (go identity)
   where
-    go :: forall p. (p -> Path Abs b) -> (p -> Path a b) -> p -> Maybe (Path a b)
-    go f coe p =
-      if goesUp (f p `relativeTo` root)
-        then Nothing
-        else Just (coe p)
-    goesUp :: forall x y. Path x y -> Boolean
-    goesUp = foldPath false (const true) (\p _ -> goesUp p)
+  go :: forall p. (p -> Path Abs b) -> (p -> Path a b) -> p -> Maybe (Path a b)
+  go f coe p =
+    if goesUp (f p `relativeTo` root) then Nothing
+    else Just (coe p)
+
+  goesUp :: forall x y. Path x y -> Boolean
+  goesUp = foldPath false (const true) (\p _ -> goesUp p)
 
 -- | Sandboxes any path to `/`.
 -- |

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -23,16 +23,15 @@ import Test.QuickCheck.Gen as Gen
 import Unsafe.Coerce (unsafeCoerce)
 
 test :: forall a. Show a => Eq a => String -> a -> a -> Effect Unit
-test name actual expected= do
+test name actual expected = do
   info $ "Test: " <> name
-  if expected == actual
-    then info $ "Passed: " <> (show expected)
-    else throw $ "Failed:\n    Expected: " <> (show expected) <> "\n    Actual:   " <> (show actual)
+  if expected == actual then info $ "Passed: " <> (show expected)
+  else throw $ "Failed:\n    Expected: " <> (show expected) <> "\n    Actual:   " <> (show actual)
 
 test' :: forall a b. IsRelOrAbs a => IsDirOrFile b => String -> Path a b -> String -> Effect Unit
 test' n p s = test n (printTestPath p) s
 
-pathPart ∷ Gen.Gen NonEmptyString
+pathPart :: Gen.Gen NonEmptyString
 pathPart = asNonEmptyString <$> Gen.suchThat QC.arbitrary (not <<< Str.null)
   where
   asNonEmptyString :: String -> NonEmptyString
@@ -49,12 +48,14 @@ dirBaz = dir (Proxy :: Proxy "baz")
 
 parsePrintCheck :: forall a b. IsRelOrAbs a => IsDirOrFile b => Path a b -> Maybe (Path a b) -> QC.Result
 parsePrintCheck input parsed =
-  if parsed == Just input
-    then QC.Success
-    else QC.Failed
-      $ "`parse (print path) != Just path` for path: `" <> show input <> "` which was re-parsed into `" <> show parsed <> "`"
-      <> "\n\tPrinted path: " <> show (printTestPath input)
-      <> "\n\tPrinted path': `" <> show (map (printTestPath) parsed) <> "`"
+  if parsed == Just input then QC.Success
+  else QC.Failed
+    $ "`parse (print path) != Just path` for path: `" <> show input <> "` which was re-parsed into `" <> show parsed <> "`"
+        <> "\n\tPrinted path: "
+        <> show (printTestPath input)
+        <> "\n\tPrinted path': `"
+        <> show (map (printTestPath) parsed)
+        <> "`"
 
 parsePrintAbsDirPath :: Gen.Gen QC.Result
 parsePrintAbsDirPath = PG.genAbsDirPath <#> \path ->
@@ -109,15 +110,18 @@ checkRelative gen = do
   let rel = p1 `relativeTo` p2
   let p1' = p2 </> rel
   pure
-    if p1 == p1'
-      then QC.Success
-      else
-        QC.Failed
-          $ "`relativeTo` property did not hold:"
-          <> "\n\tp1:  " <> printTestPath p1
-          <> "\n\tp2:  " <> printTestPath p2
-          <> "\n\trel:  " <> printTestPath rel
-          <> "\n\tp1': " <> printTestPath p1'
+    if p1 == p1' then QC.Success
+    else
+      QC.Failed
+        $ "`relativeTo` property did not hold:"
+            <> "\n\tp1:  "
+            <> printTestPath p1
+            <> "\n\tp2:  "
+            <> printTestPath p2
+            <> "\n\trel:  "
+            <> printTestPath rel
+            <> "\n\tp1': "
+            <> printTestPath p1'
 
 main :: Effect Unit
 main = do
@@ -159,19 +163,22 @@ main = do
     "C:\\bar\\"
 
   test' "(</>) - file with two parents"
-    (dirFoo
-      </> dirBar
-      </> file (Proxy :: Proxy "image.png"))
+    ( dirFoo
+        </> dirBar
+        </> file (Proxy :: Proxy "image.png")
+    )
     "./foo/bar/image.png"
 
   test' "(<.>) - file without extension"
-    (file (Proxy :: Proxy "image")
-      <.> "png")
+    ( file (Proxy :: Proxy "image")
+        <.> "png"
+    )
     "./image.png"
 
   test' "(<.>) - file with extension"
-    (file (Proxy :: Proxy "image.jpg")
-      <.> "png")
+    ( file (Proxy :: Proxy "image.jpg")
+        <.> "png"
+    )
     "./image.png"
 
   test' "printPath - ./../"


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
